### PR TITLE
#166165507 Only staff can debit and credit account

### DIFF
--- a/server/middlewares/authentication.js
+++ b/server/middlewares/authentication.js
@@ -42,14 +42,14 @@ export const adminAuth = (req, res, next) => {
 };
 
 export const staffAuth = (req, res, next) => {
-  const { type } = req.user;
-  if (type !== 'staff') {
-    res.status(403).json({
+  const { type, isadmin } = req.user;
+  if (type !== 'staff' || isadmin === true) {
+    return res.status(403).json({
       status: 403,
       error: 'Unauthorized! Accessible to staff only',
     });
   }
-  next();
+  return next();
 };
 
 export const clientAuth = (req, res, next) => {

--- a/server/tests/accountTest.js
+++ b/server/tests/accountTest.js
@@ -163,8 +163,9 @@ describe('ACCOUNT TEST', () => {
     before(async () => {
       const response = await chai
         .request(app)
-        .post('/api/v1/auth/signin')
-        .send({ email: clientField.email, password: clientField.password });
+        .post('/api/v1/auth/signup')
+        .send(clientField);
+
       clientToken = response.body.data.token;
     });
 


### PR DESCRIPTION
#### What does this PR do?
Restricts transactions to only staff

#### Description of Task to be completed?
Have the following endpoint working for only staff and not admin or client:
`POST -> /api/v1/transactions/:accountNumber/credit`
`POST -> /api/v1/transactions/:accountNumber/debit`

#### How should this be manually tested?
After cloning the repo, `cd` into it and do the following:
```bash
# install dependencies
$ npm install

# run unit tests
$ npm test

# start the development server
$ npm run startDev
```
Using Postman, sign in as a `staff` and visit the route stated above

#### Any background context you want to provide?
As a staff, a request to the `POST` transactions endpoint will return an object with data, while for admin and client it returns an error unauthorized.

#### What are the relevant pivotal tracker stories?
[#166165507 ](https://www.pivotaltracker.com/story/show/166165507)

#### Screenshots (if appropriate)
##### As a staff
![transaction](https://user-images.githubusercontent.com/28323234/58259483-8a324100-7d6c-11e9-97e3-9ba283e767d1.PNG)

##### As a client or admin
![transaction2](https://user-images.githubusercontent.com/28323234/58259859-4d1a7e80-7d6d-11e9-9a36-ebcac037c731.PNG)

