### PR TITLE
#166234757- Refactor User Controller and Add Signup Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 Banka is a light-weight core banking application that powers banking operations like account creation, customer deposit and withdrawals. This app is meant to support a single bank, where users can signup and create bank accounts online, but must visit the branch to withdraw or deposit money.
 
 [![Build Status](https://travis-ci.com/LukasChiama/Banka.svg?branch=develop)](https://travis-ci.com/LukasChiama/Banka)
-[![Coverage Status](https://coveralls.io/repos/github/LukasChiama/Banka/badge.svg?branch=develop&service=github)](https://coveralls.io/github/LukasChiama/Banka?branch=develop)
-[![Maintainability](https://api.codeclimate.com/v1/badges/1d5dac171d529f87e2da/maintainability)](https://codeclimate.com/github/halimahO/Banka/maintainability)
+[![Coverage Status](https://coveralls.io/repos/github/LukasChiama/Banka/badge.svg?branch=develop)](https://coveralls.io/github/LukasChiama/Banka?branch=develop)
+[![Maintainability](https://api.codeclimate.com/v1/badges/cae35823f4a5c5d6f70b/maintainability)](https://codeclimate.com/github/LukasChiama/Banka/maintainability)
 
 
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,13 @@
   "directories": {
     "test": "tests"
   },
+  "nyc": {
+    "require": [
+      "@babel/register"
+    ]
+  },
   "scripts": {
-    "test": "npm run dbtest && nyc mocha --timeout 1000000 --exit --require @babel/register --require @babel/polyfill ./server/tests/**/*.js || true",
+    "test": "npm run dbtest && nyc mocha --timeout 1000000 --exit ./server/tests/**/*.js || true",
     "start": "npm run build && node build/index.js",
     "startDev": "nodemon --exec babel-node server/index.js",
     "build": "npm run clean && babel server --out-dir build",

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -17,22 +17,36 @@ export default class UsersController {
     }
     let newUser;
     try {
-      newUser = await user.signUp();
+      if (req.url.includes('admin')) {
+        newUser = await user.createAdmin();
+      } else if (req.url.includes('staff')) {
+        newUser = await user.createStaff();
+      } else {
+        newUser = await user.signUp();
+      }
     } catch (error) {
       return error.message;
     }
 
     const {
-      id, firstname, lastname, email,
-      type, isadmin,
+      id, firstname, lastname, email, type, isadmin,
     } = newUser;
 
     const token = await Jwt.generateToken({
-      id, email, type, isadmin, firstname, lastname,
+      id,
+      email,
+      type,
+      isadmin,
+      firstname,
+      lastname,
     });
 
     const response = {
-      token, id, firstname, lastname, email,
+      token,
+      id,
+      firstname,
+      lastname,
+      email,
     };
     return res.status(201).json({
       status: 201,
@@ -40,82 +54,6 @@ export default class UsersController {
     });
   }
 
-  static async createStaff(req, res) {
-    const user = new User(req.body);
-
-    user.password = hashPassword(user.password);
-
-    const userExists = await User.getUserByEmail(user.email);
-    if (userExists) {
-      return res.status(409).json({
-        status: 409,
-        error: 'This email address is already taken.',
-      });
-    }
-
-    let newUser;
-    try {
-      newUser = await user.createStaff();
-    } catch (error) {
-      return error.message;
-    }
-
-    const {
-      id, firstname, lastname, email,
-      type, isadmin,
-    } = newUser;
-
-    const token = await Jwt.generateToken({
-      id, email, type, isadmin, firstname, lastname,
-    });
-
-    const response = {
-      token, id, firstname, lastname, email,
-    };
-
-    return res.status(201).json({
-      status: 201,
-      data: response,
-    });
-  }
-
-  static async createAdmin(req, res) {
-    const user = new User(req.body);
-
-    user.password = hashPassword(user.password);
-
-    const userExists = await User.getUserByEmail(user.email);
-    if (userExists) {
-      return res.status(409).json({
-        status: 409,
-        error: 'This email address is already taken.',
-      });
-    }
-
-    let newUser;
-    try {
-      newUser = await user.createAdmin();
-    } catch (error) {
-      return error.message;
-    }
-    const {
-      id, firstname, lastname, email,
-      type, isadmin,
-    } = newUser;
-
-    const token = await Jwt.generateToken({
-      id, email, type, isadmin, firstname, lastname,
-    });
-
-    const response = {
-      token, id, firstname, lastname, email,
-    };
-
-    return res.status(201).json({
-      status: 201,
-      data: response,
-    });
-  }
 
   static async signin(req, res) {
     const { email, password } = req.body;
@@ -143,16 +81,24 @@ export default class UsersController {
     }
 
     const {
-      id, firstname, lastname,
-      type, isadmin,
+      id, firstname, lastname, type, isadmin,
     } = result;
 
     const token = await Jwt.generateToken({
-      id, email, type, isadmin, firstname, lastname,
+      id,
+      email,
+      type,
+      isadmin,
+      firstname,
+      lastname,
     });
 
     const response = {
-      token, id, firstname, lastname, email,
+      token,
+      id,
+      firstname,
+      lastname,
+      email,
     };
 
     return res.status(200).json({
@@ -188,7 +134,11 @@ export default class UsersController {
         createdon, accountnumber, type, status, balance,
       } = rest;
       return {
-        createdon, accountnumber, type, status, balance,
+        createdon,
+        accountnumber,
+        type,
+        status,
+        balance,
       };
     });
     return res.status(200).json({
@@ -212,8 +162,8 @@ export default class UsersController {
     return res.status(200).json({
       status: res.statusCode,
       message: 'Password Changed Successfully',
-  })
-}
+    });
+  }
 
   static async getAllUsers(req, res) {
     const users = await User.getAllUsers();
@@ -227,10 +177,7 @@ export default class UsersController {
       }
       const results = users.map((result) => {
         const {
-          id,
-          firstname,
-          lastname,
-          email,
+          id, firstname, lastname, email,
         } = result;
         return {
           id,

--- a/server/routes/userRoute.js
+++ b/server/routes/userRoute.js
@@ -6,16 +6,20 @@ import paramsValidate from '../middlewares/validateParams';
 
 const userRouter = new Router();
 const {
-  signUp, signin, allUserAccounts, createStaff, createAdmin, getAllUsers, changePassword
+  signUp,
+  signin,
+  allUserAccounts,
+  getAllUsers,
+  changePassword,
 } = userController;
 
 userRouter.post('/auth/signup', userValidate.client, signUp);
 
 userRouter.post('/auth/signin', userValidate.login, signin);
 
-userRouter.post('/staff', requireAuth, adminAuth, userValidate.login, createStaff);
+userRouter.post('/auth/signup/staff', requireAuth, adminAuth, userValidate.login, signUp);
 
-userRouter.post('/admin', requireAuth, adminAuth, userValidate.login, createAdmin);
+userRouter.post('/auth/signup/admin', requireAuth, adminAuth, userValidate.login, signUp);
 
 userRouter.patch('/auth/change-password', requireAuth, userValidate.changePassword, changePassword);
 

--- a/server/tests/accountTest.js
+++ b/server/tests/accountTest.js
@@ -1,3 +1,4 @@
+import '@babel/polyfill';
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import app from '../index';

--- a/server/tests/testData.js
+++ b/server/tests/testData.js
@@ -8,6 +8,22 @@ const wrongTransactionId = {
 };
 
 // user
+const seededAdmin = {
+  email: 'adebade@gmail.com',
+  firstname: 'Ade',
+  lastname: 'Bade',
+  id: 1,
+  type: 'staff',
+  isadmin: true,
+};
+
+const existingEmail = {
+  email: 'adebade@gmail.com',
+  firstname: 'Ade',
+  lastname: 'Bade',
+  password: 'passwords',
+};
+
 const clientField = {
   email: 'testClient@gmail.com',
   password: 'asdfghjkl',
@@ -273,4 +289,6 @@ export {
   clientTransfer,
   newAccount,
   newTrans,
+  existingEmail,
+  seededAdmin,
 };


### PR DESCRIPTION
#### What does this PR do?

- Refactor user controller by eliminating repeated lines of code and controllers

- Use a single controller for sign up

- Write tests to cover successful user sign up


#### Description of Task to be completed?

- Ensure client, staff and admin signup are working and use the same route

#### How should this be manually tested?

- Clone the repo and run `npm run test` command from the root folder

- From Postman, make POST requests to the signup endpoints

#### Any background context you want to provide?
The user controller class had three static functions that accomplished almost the same function. This repetition led to poor maintenance on the code base. This commit handles that and writes tests to handle signup cases that weren't handled before

#### What are the relevant pivotal tracker stories?
[#166234757](https://www.pivotaltracker.com/story/show/166234757)